### PR TITLE
Add support for outputDimension

### DIFF
--- a/source/image-handler/index.ts
+++ b/source/image-handler/index.ts
@@ -37,7 +37,7 @@ export async function handler(event: ImageHandlerEvent): Promise<ImageHandlerExe
       }).promise();
 
       const headers = {
-        "Content-Type": "image/png",
+        "Content-Type": "image/webp",
         "Cache-Control": "max-age=31536000,public,immutable",
         "Last-Modified": "Thu, 01 Jan 1970 00:00:00 GMT",
         "Expires": "Thu, 31 Dec 2037 23:55:55 GMT",
@@ -96,7 +96,7 @@ export async function handler(event: ImageHandlerEvent): Promise<ImageHandlerExe
       Bucket: "ntmg-media",
       Key: buildS3CacheKey(event.path),
       Body: Buffer.from(processedRequest, "base64"),
-      ContentType: "image/png",
+      ContentType: "image/webp",
     }).promise();
     console.timeEnd("putObject()");
 

--- a/source/image-handler/lib/interfaces.ts
+++ b/source/image-handler/lib/interfaces.ts
@@ -47,6 +47,9 @@ export interface TilerImageRequest {
   x: number;
   y: number;
   zoom: number;
+
+  // Width and height of the square image in pixels
+  outputDimension?: number;
 }
 
 export interface BoundingBox {

--- a/source/image-handler/tiler.ts
+++ b/source/image-handler/tiler.ts
@@ -89,7 +89,7 @@ function imageSizeAfterRotation(size: [number, number], degrees: number): [numbe
 
 export const getTileImage = async (imageRequestInfo: ImageRequestInfo): Promise<sharp.Sharp> => {
   const tilerParams = imageRequestInfo.tilerParams;
-  const { x, y, zoom, overlayWidthInMeters, rotationDegrees, topLeftLat, topLeftLong, aspectRatioWidth, aspectRatioHeight } = tilerParams;
+  const { x, y, zoom, overlayWidthInMeters, rotationDegrees, topLeftLat, topLeftLong, aspectRatioWidth, aspectRatioHeight, outputDimension } = tilerParams;
 
   const scale = Math.pow(2, zoom);
 
@@ -210,8 +210,10 @@ export const getTileImage = async (imageRequestInfo: ImageRequestInfo): Promise<
 
   console.timeEnd("extend()");
 
+  const outputWidth = outputDimension ?? 256;
+  const outputHeight = outputDimension ?? 256;
 
-  if (right - left > 256 || bottom - top > 256) {
+  if (right - left > outputWidth || bottom - top > outputHeight) {
     console.time("toBuffer()");
     
     const buffer = await imageTile.toBuffer();
@@ -219,11 +221,12 @@ export const getTileImage = async (imageRequestInfo: ImageRequestInfo): Promise<
     console.timeEnd("toBuffer()");
 
     console.time("resize()");
-    
-    const resizedImage = sharp(buffer).resize(256, 256, {fit: 'fill'}).webp({
-      nearLossless: true,
-      quality: 60,
-    });
+    const resizedImage = sharp(buffer)
+      .resize(outputWidth, outputHeight, {fit: 'fill'})
+      .webp({
+        nearLossless: true,
+        quality: 80,
+      });
 
     console.timeEnd("resize()");
 
@@ -232,6 +235,6 @@ export const getTileImage = async (imageRequestInfo: ImageRequestInfo): Promise<
 
   return imageTile.webp({
     nearLossless: true,
-    quality: 60,
+    quality: 80,
   });
 };


### PR DESCRIPTION
The outputDimension tiler parameter affects the dimensions of tile images. For example, if outputDimension=512 then 512x512 tiles will be returned.
